### PR TITLE
Fix build errors for MSVC 14.0

### DIFF
--- a/prettyprint.hpp
+++ b/prettyprint.hpp
@@ -157,7 +157,7 @@ namespace pretty_print
     template <typename T1, typename T2>
     struct print_container_helper<T, TChar, TCharTraits, TDelimiters>::printer<std::pair<T1, T2>>
     {
-        using ostream_type = print_container_helper<T, TChar, TCharTraits, TDelimiters>::ostream_type;
+        using ostream_type = typename print_container_helper<T, TChar, TCharTraits, TDelimiters>::ostream_type;
 
         static void print_body(const std::pair<T1, T2> & c, ostream_type & stream)
         {
@@ -174,7 +174,7 @@ namespace pretty_print
     template <typename ...Args>
     struct print_container_helper<T, TChar, TCharTraits, TDelimiters>::printer<std::tuple<Args...>>
     {
-        using ostream_type = print_container_helper<T, TChar, TCharTraits, TDelimiters>::ostream_type;
+        using ostream_type = typename print_container_helper<T, TChar, TCharTraits, TDelimiters>::ostream_type;
         using element_type = std::tuple<Args...>;
 
         template <std::size_t I> struct Int { };


### PR DESCRIPTION
This commit fixes errors when building on Windows with MSVC++ 14.0 and greater.

Fixes #18 and #20.

I've tested these changes against a project that also compiles using GCC 5.0+ and Clang 3.4+ and I'm not seeing any issues with them, so everything should be safe.
