### PR TITLE
Accept iterators with a non-void value_type

### DIFF
--- a/prettyprint.hpp
+++ b/prettyprint.hpp
@@ -38,7 +38,8 @@ namespace pretty_print
         struct has_const_iterator : private sfinae_base
         {
         private:
-            template <typename C> static yes & test(typename C::const_iterator*);
+            template <typename C>
+            static typename std::enable_if<!std::is_void<typename std::iterator_traits<typename C::const_iterator>::value_type>::value, yes &>::type test(typename C::const_iterator*);
             template <typename C> static no  & test(...);
         public:
             static const bool value = sizeof(test<T>(nullptr)) == sizeof(yes);


### PR DESCRIPTION
This PR changes `has_const_iterator` to additionally check
1) for `std::iterator_traits` to exist and
2) for its `return_type` to be non-`void`.

This catches additional cases and is compatible with the iterator rules up to C++20.

Motivation for this change is the incompatibility with the new [iterator interface of Eigen3](https://bitbucket.org/eigen/eigen/src/default/Eigen/src/Core/StlIterators.h), which sets `const_iterator = void` for non-vector types. This breaks `prettyprint`.